### PR TITLE
Fix bad indent for buildName

### DIFF
--- a/FileSpec/example3.yml
+++ b/FileSpec/example3.yml
@@ -5,7 +5,7 @@ resources:
       sourceArtifactory: s_artifactory
       pattern: "test-local/setup/"
       recursive: false
-	  buildName: pipelines_api
+      buildName: pipelines_api
       buildNumber: 1@3
 
 pipelines:


### PR DESCRIPTION
The file `FileSpec/example3.yml` had a tab as an indent for `buildName`, which conflicted with the rest of the file's structure.